### PR TITLE
fix excluded directory trailing slash bug

### DIFF
--- a/modules/file-is-excluded.js
+++ b/modules/file-is-excluded.js
@@ -1,0 +1,8 @@
+module.exports = (filePath, config) => {
+  const path = require('path'),
+    parsed = path.parse(filePath),
+    isExcludedFile = config.exclude.files && config.exclude.files.includes(filePath),
+    isExcludedDir = config.exclude.directories && new RegExp('^' + config.exclude.directories.join('|^')).test(parsed.dir + '/');
+
+  return !!isExcludedFile || !!isExcludedDir;
+};

--- a/modules/file-is-excluded.test.js
+++ b/modules/file-is-excluded.test.js
@@ -1,0 +1,13 @@
+const test = require('ava'),
+      fileIsExcluded = require('./file-is-excluded');
+
+test('should exclude mentioned files', (t) => {
+  t.is(fileIsExcluded('exclude/me.txt', {exclude: {files: ['exclude/me.txt']}}), true);
+  t.is(fileIsExcluded('include/me.txt', {exclude: {files: ['exclude/me.txt']}}), false);
+});
+
+test('should exclude mentioned directories', (t) => {
+  t.is(fileIsExcluded('exclude/me.txt', {exclude: {directories: ['exclude/']}}), true);
+  t.is(fileIsExcluded('exclude/me.txt', {exclude: {directories: ['exclude']}}), true); // trailing slash test
+  t.is(fileIsExcluded('include/me.txt', {exclude: {directories: ['exclude/']}}), false);
+});


### PR DESCRIPTION
Prior to this patch there was a bug in the excluded directory check due
to `path.dir` stripping the trailing slash off of the examined file. It
could be fixed by not including the trailing slash in the configuration,
but that would allow an excluded directory of `foo/bar` to also match
`foo/baroops`.

This patch appends a trailing slash to `path.dir` and matches against
that. It also breaks the method out into it's own file so we can test
it.