### PR TITLE
Adds sha blacklisting

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - 10
+  - 12

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
+  - 8
   - 10
   - 12

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Then you will have `pythia` as a command that you can run from your console!
 
 Adding `-p` or `--publish` to pythia will run the publish config and send the list
 of reviewers to your code review system. It does this by calling `.pythia-publish`
-passing it the email of the author, ownership percentage, and location of the file. 
-You can write a `.pythia-publish` file to do whatever you need it to do for your 
+passing it the email of the author, ownership percentage, and location of the file.
+You can write a `.pythia-publish` file to do whatever you need it to do for your
 review system.
 
 As an example, for gerrit you might do something like this:
@@ -70,6 +70,7 @@ look like this:
   "exclude": {
     "users": ["dsellers@example.com", "theOracle@example.com", "mreynolds@example.com"],
     "files": ["readme.md", "history.md", "AUTHORS"],
+    "shas": ["1acdb7ea77d8afec3e5bc2cd021c914ca4302265", "e488831"]
     "directories": ["bin"],
     "comments": { ".rb": "#", ".js": "//" }
   },
@@ -77,8 +78,8 @@ look like this:
 }
 ```
 
-With `exclude.comments`, you can exclude lines starting with specific characters 
-for the given file extensions. 
+With `exclude.comments`, you can exclude lines starting with specific characters
+for the given file extensions.
 
 ### command line argument
 

--- a/bin/pythia
+++ b/bin/pythia
@@ -1,67 +1,63 @@
 #!/usr/bin/env node
 
-const processFile = require('../modules/process-file'),
-      cp = require('child_process'),
-      fs = require('fs'),
-      path = require('path'),
-      readConfig = require('../modules/read-config'),
-      writeHeader = () => {
-        console.log('\n\n\n');
-        console.log(fs.readFileSync(path.join(__dirname, '../modules/header.txt'), 'utf8'));
-        console.log('\nLooking into the past to save the future...\n');
-        console.log('-------------------------------------------');
-      },
-      writeFooter = () => {
-        console.log('-------------------------------------------');
-        console.log('');
-      },
-      getConfigFileLocation = () => {
-        const indx = process.argv.indexOf('--config') + 1;
+const processFile = require('../modules/process-file');
+const cp = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const readConfig = require('../modules/read-config');
+const { writeHeader, writeFooter } = require('../modules/output');
+const getConfigFileLocation = () => {
+  const indx = process.argv.indexOf('--config') + 1;
 
-        if (indx + 1 > process.argv.length || /^--/.exec(process.argv[indx])) {
-          console.log('Please provide a file with your --config flag');
-          process.exit(1);
-        }
-
-        return process.argv.indexOf('--config') > 0 ? process.argv[indx] : undefined;
-      }
-      config = readConfig(getConfigFileLocation()),
-      publishReviewRequests = process.argv.includes('--publish') || process.argv.includes('-p')
-      isExcluded = (filePath) => {
-        const parsed = path.parse(filePath),
-              isExcludedFile = config.exclude.files.includes(filePath),
-              isExcludedDir = config.exclude.directories.length
-                ? new RegExp('^' + config.exclude.directories.join('|^')).test(parsed.dir)
-                : false;
-
-        return isExcludedFile || isExcludedDir;
-      };
-
-writeHeader();
-cp.exec('git diff-tree --no-commit-id --name-only -r HEAD', (error, stdout, stderr) => {
-  if (error) {
-    console.log('Well.... something broke. Bad.');
+  if (indx + 1 > process.argv.length || /^--/.exec(process.argv[indx])) {
+    console.log('Please provide a file with your --config flag');
+    process.exit(1);
   }
 
-  cp.exec('git log --format="%ae" -n 1', (err, out) => {
-    // split on lines to get the list of files
-    stdout.split('\n').forEach((file) => {
-      const filePath = path.join(process.cwd(), file);
+  return process.argv.indexOf('--config') > 0 ? process.argv[indx] : undefined;
+};
 
-      fs.stat(filePath, (err, stat) => {
-        if (!err && stat.isFile() && !isExcluded(file)) {
-          processFile({
-            file,
-            excludeUsers: config.exclude.users,
-            publish: publishReviewRequests,
-            currentAuthor: out.replace(/\n$/, ''),
-            config
-          });
-        }
+const config = readConfig(getConfigFileLocation());
+const publishReviewRequests =
+  process.argv.includes('--publish') || process.argv.includes('-p');
+const isExcluded = filePath => {
+  const parsed = path.parse(filePath),
+    isExcludedFile = config.exclude.files.includes(filePath),
+    isExcludedDir = config.exclude.directories.length
+      ? new RegExp('^' + config.exclude.directories.join('|^')).test(parsed.dir)
+      : false;
+
+  return isExcludedFile || isExcludedDir;
+};
+
+writeHeader();
+cp.exec(
+  'git diff-tree --no-commit-id --name-only -r HEAD',
+  (error, stdout, stderr) => {
+    if (error) {
+      console.log('Well.... something broke. Bad.');
+    }
+
+    cp.exec('git log --format="%ae" -n 1', (err, out) => {
+      // split on lines to get the list of files
+      stdout.split('\n').forEach(file => {
+        const filePath = path.join(process.cwd(), file);
+
+        fs.stat(filePath, (err, stat) => {
+          if (!err && stat.isFile() && !isExcluded(file)) {
+            processFile({
+              file,
+              excludeUsers: config.exclude.users,
+              publish: publishReviewRequests,
+              currentAuthor: out.replace(/\n$/, ''),
+              config
+            });
+          }
+        });
       });
     });
-  });
-});
+  }
+);
 
 process.on('exit', () => {
   writeFooter();

--- a/bin/pythia
+++ b/bin/pythia
@@ -30,7 +30,9 @@ const processFile = require('../modules/process-file'),
       isExcluded = (filePath) => {
         const parsed = path.parse(filePath),
               isExcludedFile = config.exclude.files.includes(filePath),
-              isExcludedDir = new RegExp('^' + config.exclude.directories.join('|^')).test(parsed.dir);
+              isExcludedDir = config.exclude.directories.length
+                ? new RegExp('^' + config.exclude.directories.join('|^')).test(parsed.dir)
+                : false;
 
         return isExcludedFile || isExcludedDir;
       };

--- a/fixtures/.exclude-shas-config
+++ b/fixtures/.exclude-shas-config
@@ -1,0 +1,9 @@
+{
+  "exclude": {
+    "files": [
+      "file-one",
+      "file-two"
+    ],
+    "shas": ["bed1a172"]
+  }
+}

--- a/history.md
+++ b/history.md
@@ -1,169 +1,138 @@
-### - 0.6.0 * 8/1/2019, 8:22:17 PM *
+### - 0.6.0 _ 8/1/2019, 8:22:17 PM _
 
-  
+### - 0.5.9 _ 8/1/2019, 8:22:06 PM _
 
+### - 0.5.8 _ 8/1/2019, 8:21:52 PM _
 
- ### - 0.5.9 * 8/1/2019, 8:22:06 PM *
+- Update vulnerable sub dependencies
+- Merge pull request #24 from pjozsef/master
+- Merge branch 'master' into master
+- feat(process): do not count comments
+- fix(process): do not count empty buffer in pipeline stream
+- Trying to come up with a testcase for processFile
+- feat(config): enable the exclusion of commented lines in config
+- chore(gitignore): ignore .idea folder
+- test(config): add test cases for parsing config file
 
-  
+### - 0.5.7 _ 7/10/2019, 10:05:09 AM _
 
+- Merge pull request #25 from designfrontier/greenkeeper/ava-2.2.0
+- Closes vulnerabilities
+- Updates the lock file and the test command
+- chore(package): update lockfile package-lock.json
+- chore(package): update ava to version 2.2.0
 
- ### - 0.5.8 * 8/1/2019, 8:21:52 PM *
+### - 0.5.6 _ 2019-1-7 10:12:09 _
 
-   - Update vulnerable sub dependencies
-  - Merge pull request #24 from pjozsef/master
-  - Merge branch 'master' into master
-  - feat(process): do not count comments
-  - fix(process): do not count empty buffer in pipeline stream
-  - Trying to come up with a testcase for processFile
-  - feat(config): enable the exclusion of commented lines in config
-  - chore(gitignore): ignore .idea folder
-  - test(config): add test cases for parsing config file 
+- updated versions of ava
+- Merge pull request #22 from designfrontier/greenkeeper/ava-1.0.1
+- chore(package): update lockfile package-lock.json
+- chore(package): update ava to version 1.0.1
 
+### - 0.5.5 _ 2018-8-3 12:46:36 _
 
- ### - 0.5.7 * 7/10/2019, 10:05:09 AM *
+- Merge pull request #21 from phallstrom/is-excluded
+- fix excluded directory trailing slash bug
+- 0.5.4
+- preparing for release of v0.5.4
+- security fix
+- Merge pull request #19 from designfrontier/greenkeeper/initial
+- docs(readme): add Greenkeeper badge
+- Delete foresight.sh
 
-   - Merge pull request #25 from designfrontier/greenkeeper/ava-2.2.0
-  - Closes vulnerabilities
-  - Updates the lock file and the test command
-  - chore(package): update lockfile package-lock.json
-  - chore(package): update ava to version 2.2.0 
+### - 0.5.4 _ 6/25/2018, 10:13:08 PM _
 
+- security fix
+- Merge pull request #19 from designfrontier/greenkeeper/initial
+- docs(readme): add Greenkeeper badge
+- Delete foresight.sh
 
- ### - 0.5.6 * 2019-1-7 10:12:09 *
+### - 0.5.3 _ 2018-4-16 10:38:12 _
 
-   - updated versions of ava
-  - Merge pull request #22 from designfrontier/greenkeeper/ava-1.0.1
-  - chore(package): update lockfile package-lock.json
-  - chore(package): update ava to version 1.0.1 
+- Merge pull request #16 from designfrontier/bug/dir-to-regex-exclude
+- fixes a bug where sub-directories escaped the exclude
+- 0.5.2
+- preparing for release of v0.5.2
+- 0.5.1
+- preparing for release of v0.5.1
+- cleaning up the readme a bit
+- 0.5.0
+- preparing for release of v0.5.0
+- Adds ability to pass in a config file as an arg
+- Adds the ability to set the threshold in config
+- Merge pull request #14 from designfrontier/add-license-1
+- Create LICENSE
+- Merge pull request #13 from designfrontier/add-code-of-conduct-1
+- Create CODE_OF_CONDUCT.md
 
+### - 0.5.2 _ 2018-4-11 06:38:46 _
 
- ### - 0.5.5 * 2018-8-3 12:46:36 *
+### - 0.5.1 _ 2018-4-11 06:38:04 _
 
-   - Merge pull request #21 from phallstrom/is-excluded
-  - fix excluded directory trailing slash bug
-  - 0.5.4
-  - preparing for release of v0.5.4
-  - security fix
-  - Merge pull request #19 from designfrontier/greenkeeper/initial
-  - docs(readme): add Greenkeeper badge
-  - Delete foresight.sh 
+- cleaning up the readme a bit
 
+### - 0.5.0 _ 2018-4-11 06:32:26 _
 
- ### - 0.5.4 * 6/25/2018, 10:13:08 PM *
+- Adds ability to pass in a config file as an arg
+- Adds the ability to set the threshold in config
+- Merge pull request #14 from designfrontier/add-license-1
+- Create LICENSE
+- Merge pull request #13 from designfrontier/add-code-of-conduct-1
+- Create CODE_OF_CONDUCT.md
+- 0.4.0
+- preparing for release of v0.4.0
+- Merge pull request #11 from rwstauner/file-paths
+- Exclude full file paths rather than base name
+- 0.3.2
+- preparing for release of v0.3.2
+- Update check-ownership.js
+- 0.3.1
+- preparing for release of v0.3.1
+- Merge pull request #10 from designfrontier/fix-package-json
+- has dev deps in deps
+- 0.3.0
+- preparing for release of v0.3.0
+- 0.2.2
+- preparing for release of v0.2.2
+- Merge pull request #8 from rwstauner/emails
+- Merge pull request #9 from rwstauner/whitespace
+- Merge pull request #7 from rwstauner/args
+- Ignore whitespace when looking for changes
+- Document that excluded users should include full email address
+- Pass author, ownership, and filePath as args to publish script
 
-   - security fix
-  - Merge pull request #19 from designfrontier/greenkeeper/initial
-  - docs(readme): add Greenkeeper badge
-  - Delete foresight.sh 
+### - 0.4.0 _ 2018-4-6 16:22:26 _
 
+- Merge pull request #11 from rwstauner/file-paths
+- Exclude full file paths rather than base name
 
- ### - 0.5.3 * 2018-4-16 10:38:12 *
+### - 0.3.2 _ 2018-4-6 13:21:46 _
 
-   - Merge pull request #16 from designfrontier/bug/dir-to-regex-exclude
-  - fixes a bug where sub-directories escaped the exclude
-  - 0.5.2
-  - preparing for release of v0.5.2
-  - 0.5.1
-  - preparing for release of v0.5.1
-  - cleaning up the readme a bit
-  - 0.5.0
-  - preparing for release of v0.5.0
-  - Adds ability to pass in a config file as an arg
-  - Adds the ability to set the threshold in config
-  - Merge pull request #14 from designfrontier/add-license-1
-  - Create LICENSE
-  - Merge pull request #13 from designfrontier/add-code-of-conduct-1
-  - Create CODE_OF_CONDUCT.md 
+- Update check-ownership.js
 
+### - 0.3.1 _ 2018-4-6 12:44:36 _
 
- ### - 0.5.2 * 2018-4-11 06:38:46 *
+- Merge pull request #10 from designfrontier/fix-package-json
+- has dev deps in deps
 
-  
+### - 0.3.0 _ 2018-4-6 10:47:08 _
 
+### - 0.2.2 _ 2018-4-6 10:46:52 _
 
- ### - 0.5.1 * 2018-4-11 06:38:04 *
+- Merge pull request #8 from rwstauner/emails
+- Merge pull request #9 from rwstauner/whitespace
+- Merge pull request #7 from rwstauner/args
+- Ignore whitespace when looking for changes
+- Document that excluded users should include full email address
+- Pass author, ownership, and filePath as args to publish script
 
-   - cleaning up the readme a bit 
+### - 0.2.1 _ 2018-4-6 08:01:23 _
 
+- typo #1
 
- ### - 0.5.0 * 2018-4-11 06:32:26 *
+### - 0.2.0 _ 2018-4-6 07:57:14 _
 
-   - Adds ability to pass in a config file as an arg
-  - Adds the ability to set the threshold in config
-  - Merge pull request #14 from designfrontier/add-license-1
-  - Create LICENSE
-  - Merge pull request #13 from designfrontier/add-code-of-conduct-1
-  - Create CODE_OF_CONDUCT.md
-  - 0.4.0
-  - preparing for release of v0.4.0
-  - Merge pull request #11 from rwstauner/file-paths
-  - Exclude full file paths rather than base name
-  - 0.3.2
-  - preparing for release of v0.3.2
-  - Update check-ownership.js
-  - 0.3.1
-  - preparing for release of v0.3.1
-  - Merge pull request #10 from designfrontier/fix-package-json
-  - has dev deps in deps
-  - 0.3.0
-  - preparing for release of v0.3.0
-  - 0.2.2
-  - preparing for release of v0.2.2
-  - Merge pull request #8 from rwstauner/emails
-  - Merge pull request #9 from rwstauner/whitespace
-  - Merge pull request #7 from rwstauner/args
-  - Ignore whitespace when looking for changes
-  - Document that excluded users should include full email address
-  - Pass author, ownership, and filePath as args to publish script 
+- Wraps up feature set for now
+- renamed the repo
 
-
- ### - 0.4.0 * 2018-4-6 16:22:26 *
-
-   - Merge pull request #11 from rwstauner/file-paths
-  - Exclude full file paths rather than base name 
-
-
- ### - 0.3.2 * 2018-4-6 13:21:46 *
-
-   - Update check-ownership.js 
-
-
- ### - 0.3.1 * 2018-4-6 12:44:36 *
-
-   - Merge pull request #10 from designfrontier/fix-package-json
-  - has dev deps in deps 
-
-
- ### - 0.3.0 * 2018-4-6 10:47:08 *
-
-  
-
-
- ### - 0.2.2 * 2018-4-6 10:46:52 *
-
-   - Merge pull request #8 from rwstauner/emails
-  - Merge pull request #9 from rwstauner/whitespace
-  - Merge pull request #7 from rwstauner/args
-  - Ignore whitespace when looking for changes
-  - Document that excluded users should include full email address
-  - Pass author, ownership, and filePath as args to publish script 
-
-
- ### - 0.2.1 * 2018-4-6 08:01:23 *
-
-   - typo #1 
-
-
- ### - 0.2.0 * 2018-4-6 07:57:14 *
-
-   - Wraps up feature set for now
-  - renamed the repo 
-
-
- ### - 0.1.1 * 2018-4-3 22:53:28 *
-
-  
-
-
- 
+### - 0.1.1 _ 2018-4-3 22:53:28 _

--- a/modules/check-ownership.js
+++ b/modules/check-ownership.js
@@ -3,7 +3,9 @@ const cp = require('child_process')
 
 module.exports.checkOwnership = (details, publish) => {
   const { size, ownedLines, author, filePath, currentAuthor, threshold } = details;
-  const ownership = (ownedLines / size) * 100;
+  const ownership = (ownedLines / size) * 100 > 100
+    ? 100 // cap ownership percentage at 100%
+    : (ownedLines / size) * 100;
 
   if (ownership >= threshold && author !== currentAuthor) {
     if (publish)  {

--- a/modules/check-ownership.js
+++ b/modules/check-ownership.js
@@ -1,24 +1,38 @@
-const cp = require('child_process')
-      path = require('path');
+const cp = require('child_process');
+const path = require('path');
 
 module.exports.checkOwnership = (details, publish) => {
-  const { size, ownedLines, author, filePath, currentAuthor, threshold } = details;
-  const ownership = (ownedLines / size) * 100 > 100
-    ? 100 // cap ownership percentage at 100%
-    : (ownedLines / size) * 100;
+  const {
+    size,
+    ownedLines,
+    author,
+    filePath,
+    currentAuthor,
+    threshold
+  } = details;
+  const ownership =
+    (ownedLines / size) * 100 > 100
+      ? 100 // cap ownership percentage at 100%
+      : (ownedLines / size) * 100;
 
   if (ownership >= threshold && author !== currentAuthor) {
-    if (publish)  {
-      cp.execFile(path.join(process.cwd(), '.pythia-publish'), [author, ownership.toFixed(2), filePath], (err, out) => {
-        if (err) {
-          console.log(err);
-        }
+    if (publish) {
+      cp.execFile(
+        path.join(process.cwd(), '.pythia-publish'),
+        [author, ownership.toFixed(2), filePath],
+        (err, out) => {
+          if (err) {
+            console.log(err);
+          }
 
-        if (out !== '' && out !== '\n' && out !== ' ') {
-          console.log(out.replace(/\n$/, ''));
+          if (out !== '' && out !== '\n' && out !== ' ') {
+            console.log(out.replace(/\n$/, ''));
+          }
         }
-      });
+      );
     }
-    console.log(`${author} owns: ${ownership.toFixed(2)} percent of ${filePath}`);
+    console.log(
+      `${author} owns: ${ownership.toFixed(2)} percent of ${filePath}`
+    );
   }
 };

--- a/modules/file-is-excluded.js
+++ b/modules/file-is-excluded.js
@@ -1,8 +1,14 @@
+const path = require('path');
+
 module.exports = (filePath, config) => {
-  const path = require('path'),
-    parsed = path.parse(filePath),
-    isExcludedFile = config.exclude.files && config.exclude.files.includes(filePath),
-    isExcludedDir = config.exclude.directories && new RegExp('^' + config.exclude.directories.join('|^')).test(parsed.dir + '/');
+  const parsed = path.parse(filePath);
+  const isExcludedFile =
+    config.exclude.files && config.exclude.files.includes(filePath);
+  const isExcludedDir =
+    config.exclude.directories &&
+    new RegExp('^' + config.exclude.directories.join('|^')).test(
+      parsed.dir + '/'
+    );
 
   return !!isExcludedFile || !!isExcludedDir;
 };

--- a/modules/file-is-excluded.test.js
+++ b/modules/file-is-excluded.test.js
@@ -1,13 +1,36 @@
-const test = require('ava'),
-      fileIsExcluded = require('./file-is-excluded');
+const test = require('ava');
+const fileIsExcluded = require('./file-is-excluded');
 
-test('should exclude mentioned files', (t) => {
-  t.is(fileIsExcluded('exclude/me.txt', {exclude: {files: ['exclude/me.txt']}}), true);
-  t.is(fileIsExcluded('include/me.txt', {exclude: {files: ['exclude/me.txt']}}), false);
+test('should exclude mentioned files', t => {
+  t.is(
+    fileIsExcluded('exclude/me.txt', {
+      exclude: { files: ['exclude/me.txt'] }
+    }),
+    true
+  );
+  t.is(
+    fileIsExcluded('include/me.txt', {
+      exclude: { files: ['exclude/me.txt'] }
+    }),
+    false
+  );
 });
 
-test('should exclude mentioned directories', (t) => {
-  t.is(fileIsExcluded('exclude/me.txt', {exclude: {directories: ['exclude/']}}), true);
-  t.is(fileIsExcluded('exclude/me.txt', {exclude: {directories: ['exclude']}}), true); // trailing slash test
-  t.is(fileIsExcluded('include/me.txt', {exclude: {directories: ['exclude/']}}), false);
+test('should exclude mentioned directories', t => {
+  t.is(
+    fileIsExcluded('exclude/me.txt', {
+      exclude: { directories: ['exclude/'] }
+    }),
+    true
+  );
+  t.is(
+    fileIsExcluded('exclude/me.txt', { exclude: { directories: ['exclude'] } }),
+    true
+  ); // trailing slash test
+  t.is(
+    fileIsExcluded('include/me.txt', {
+      exclude: { directories: ['exclude/'] }
+    }),
+    false
+  );
 });

--- a/modules/get-email.js
+++ b/modules/get-email.js
@@ -1,4 +1,6 @@
-module.exports = (emailString) => {
-  const matches = emailString.match(/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}\b/);
+module.exports = emailString => {
+  const matches = emailString.match(
+    /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}\b/
+  );
   return matches && matches[0];
 };

--- a/modules/get-email.test.js
+++ b/modules/get-email.test.js
@@ -1,7 +1,7 @@
-const test = require('ava'),
-      getEmail = require('./get-email');
+const test = require('ava');
+const getEmail = require('./get-email');
 
-test('should return an email from a string', (t) => {
+test('should return an email from a string', t => {
   t.is(getEmail('daniel@designfrontier.net'), 'daniel@designfrontier.net');
   t.is(getEmail('This is daniel@ansble.com'), 'daniel@ansble.com');
   t.is(getEmail('This is daniel.com'), null);

--- a/modules/output.js
+++ b/modules/output.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+
+const writeHeader = () => {
+  console.log('\n\n\n');
+  console.log(
+    fs.readFileSync(path.join(__dirname, '../modules/header.txt'), 'utf8')
+  );
+  console.log('\nLooking into the past to save the future...\n');
+  console.log('-------------------------------------------');
+};
+const writeFooter = () => {
+  console.log('-------------------------------------------');
+  console.log('');
+};
+
+module.exports = {
+  writeFooter,
+  writeHeader
+};

--- a/modules/process-file.js
+++ b/modules/process-file.js
@@ -1,72 +1,86 @@
-const fs = require('fs'),
-  cp = require('child_process'),
-  path = require('path'),
-  split = require('split'),
-  getEmail = require('./get-email'),
-  utils = require('./check-ownership'),
-  isCommentLine = (line, commentChar) => commentChar && RegExp(`^\\s*${commentChar}.*`, 'i').test(line),
-  getFileLength = (file, config, cb) => {
-    const commentChar = config.exclude.comments[path.extname(file)];
-    const commentIndices = [];
-    let currentLine = 0;
+const fs = require('fs');
+const cp = require('child_process');
+const path = require('path');
+const split = require('split');
+const getEmail = require('./get-email');
+const utils = require('./check-ownership');
+const isCommentLine = (line, commentChar) =>
+  commentChar && RegExp(`^\\s*${commentChar}.*`, 'i').test(line);
+const getFileLength = (file, config, cb) => {
+  const commentChar = config.exclude.comments[path.extname(file)];
+  const commentIndices = [];
+  let currentLine = 0;
 
-    if (!file) {
-      cb();
-      return;
-    }
+  if (!file) {
+    cb();
+    return;
+  }
 
-    fs.createReadStream(file)
-      .pipe(split(null, null, { trailing: false }))
-      .on('data', (chunk) => {
-        if (isCommentLine(chunk, commentChar)) {
-          commentIndices.push(currentLine);
-        }
-        currentLine++;
-      })
-      .on('end', () => {
-        cb(currentLine - commentIndices.length, commentIndices);
-      });
-  };
-
-module.exports = ({file, excludeUsers, publish, currentAuthor, config}) => {
-  getFileLength(file, config, (lines, commentIndices) => {
-    cp.exec(`git blame -w --show-email HEAD~1 -- ${file}`, (error, stdout, stderr) => {
-      const emails = stdout.split('\n').reduce((accum, line, lineIndex) => {
-        const sha = line.split(' ').shift();
-        let prevBlame;
-
-        if (config.exclude.shas.includes(sha)) {
-          // if this line has a blacklisted sha... get the previous versions change
-          prevBlame = cp.execSync(`git blame -w --show-email ${sha}~1 -L ${lineIndex},${lineIndex} -- ${file}`).toString();
-        }
-
-        const email = prevBlame ? getEmail(prevBlame) : getEmail(line);
-
-        if (!email || excludeUsers.includes(email) || commentIndices.includes(lineIndex)) {
-          return accum;
-        }
-
-        if (typeof accum[email] !== 'undefined') {
-          accum[email] = accum[email] + 1;
-        } else {
-          accum[email] = 1;
-        }
-
-        return accum;
-
-      }, {});
-
-      Object.keys(emails).forEach((email) => {
-        // { size, ownedLines, author, file_path }
-        utils.checkOwnership({
-          size: lines,
-          ownedLines: emails[email],
-          author: email,
-          filePath: file,
-          currentAuthor,
-          threshold: config.threshold
-        }, publish);
-      });
+  fs.createReadStream(file)
+    .pipe(split(null, null, { trailing: false }))
+    .on('data', chunk => {
+      if (isCommentLine(chunk, commentChar)) {
+        commentIndices.push(currentLine);
+      }
+      currentLine++;
+    })
+    .on('end', () => {
+      cb(currentLine - commentIndices.length, commentIndices);
     });
+};
+
+module.exports = ({ file, excludeUsers, publish, currentAuthor, config }) => {
+  getFileLength(file, config, (lines, commentIndices) => {
+    cp.exec(
+      `git blame -w --show-email HEAD~1 -- ${file}`,
+      (error, stdout, stderr) => {
+        const emails = stdout.split('\n').reduce((accum, line, lineIndex) => {
+          const sha = line.split(' ').shift();
+          let prevBlame;
+
+          if (config.exclude.shas.includes(sha)) {
+            // if this line has a blacklisted sha... get the previous versions change
+            prevBlame = cp
+              .execSync(
+                `git blame -w --show-email ${sha}~1 -L ${lineIndex},${lineIndex} -- ${file}`
+              )
+              .toString();
+          }
+
+          const email = prevBlame ? getEmail(prevBlame) : getEmail(line);
+
+          if (
+            !email ||
+            excludeUsers.includes(email) ||
+            commentIndices.includes(lineIndex)
+          ) {
+            return accum;
+          }
+
+          if (typeof accum[email] !== 'undefined') {
+            accum[email] = accum[email] + 1;
+          } else {
+            accum[email] = 1;
+          }
+
+          return accum;
+        }, {});
+
+        Object.keys(emails).forEach(email => {
+          // { size, ownedLines, author, file_path }
+          utils.checkOwnership(
+            {
+              size: lines,
+              ownedLines: emails[email],
+              author: email,
+              filePath: file,
+              currentAuthor,
+              threshold: config.threshold
+            },
+            publish
+          );
+        });
+      }
+    );
   });
 };

--- a/modules/process-file.js
+++ b/modules/process-file.js
@@ -77,7 +77,7 @@ module.exports = ({ file, excludeUsers, publish, currentAuthor, config }) => {
               ownedLines: emails[email],
               author: email,
               filePath: file,
-              currentAuthor: 'bob', // currentAuthor,
+              currentAuthor,
               threshold: config.threshold
             },
             publish

--- a/modules/process-file.js
+++ b/modules/process-file.js
@@ -40,13 +40,16 @@ module.exports = ({ file, excludeUsers, publish, currentAuthor, config }) => {
 
           if (config.exclude.shas && config.exclude.shas.includes(sha)) {
             // if this line has a blacklisted sha... get the previous versions change
-            prevBlame = cp
-              .execSync(
-                `git blame -w --show-email ${sha}~1 -L ${lineIndex},${lineIndex} -- ${file}`
-              )
-              .toString();
-          }
+            do {
+              let thisSha = !!prevBlame ? prevBlame.split(' ')[0] : sha;
 
+              prevBlame = cp
+                .execSync(
+                  `git blame -w --show-email ${thisSha}~1 -L ${lineIndex},${lineIndex} -- ${file}`
+                )
+                .toString();
+            } while (config.exclude.shas.includes(prevBlame.split(' ')[0]));
+          }
           const email = prevBlame ? getEmail(prevBlame) : getEmail(line);
 
           if (
@@ -74,7 +77,7 @@ module.exports = ({ file, excludeUsers, publish, currentAuthor, config }) => {
               ownedLines: emails[email],
               author: email,
               filePath: file,
-              currentAuthor,
+              currentAuthor: 'bob', // currentAuthor,
               threshold: config.threshold
             },
             publish

--- a/modules/process-file.js
+++ b/modules/process-file.js
@@ -70,7 +70,6 @@ module.exports = ({ file, excludeUsers, publish, currentAuthor, config }) => {
         }, {});
 
         Object.keys(emails).forEach(email => {
-          // { size, ownedLines, author, file_path }
           utils.checkOwnership(
             {
               size: lines,

--- a/modules/process-file.js
+++ b/modules/process-file.js
@@ -38,7 +38,7 @@ module.exports = ({ file, excludeUsers, publish, currentAuthor, config }) => {
           const sha = line.split(' ').shift();
           let prevBlame;
 
-          if (config.exclude.shas.includes(sha)) {
+          if (config.exclude.shas && config.exclude.shas.includes(sha)) {
             // if this line has a blacklisted sha... get the previous versions change
             prevBlame = cp
               .execSync(

--- a/modules/process-file.test.js
+++ b/modules/process-file.test.js
@@ -132,3 +132,47 @@ test.cb('calls checkOwnership with comments and multiple authors', t => {
 
   processFile({ file, excludeUsers, publish, currentAuthor, config });
 });
+
+test.cb('calls git blame again if the shas is excluded', t => {
+  t.plan(2);
+
+  const blameResult = fs.readFileSync('fixtures/blame.txt', 'utf8');
+
+  const checkOwnershipStub = sandbox.stub(utils, 'checkOwnership');
+  const file = 'fixtures/blame.txt';
+  sandbox
+    .stub(cp, 'exec')
+    .withArgs(`git blame -w --show-email HEAD~1 -- ${file}`)
+    .yields(undefined, blameResult, undefined);
+
+  const excludeUsers = [];
+  const publish = false;
+  const currentAuthor = 'doug@example.com';
+  const config = {
+    threshold: 42,
+    exclude: { comments: {}, shas: ['8a83ec04'] }
+  };
+
+  const ecstub = sandbox
+    .stub(cp, 'execSync')
+    .returns(
+      Buffer.from(
+        '9a93ec03 (<alice@example.com> 2018-04-03 22:10:49 -0600 2) line 3'
+      )
+    );
+
+  checkOwnershipStub.onCall(0).callsFake((params, givenPublish) => {
+    t.deepEqual(params, {
+      author: 'alice@example.com',
+      currentAuthor: currentAuthor,
+      filePath: file,
+      ownedLines: 4,
+      size: 4,
+      threshold: config.threshold
+    });
+    t.is(givenPublish, publish);
+    t.end();
+  });
+
+  processFile({ file, excludeUsers, publish, currentAuthor, config });
+});

--- a/modules/process-file.test.js
+++ b/modules/process-file.test.js
@@ -16,7 +16,10 @@ test.cb('calls checkOwnership with the appropriate arguments', t => {
 
   const checkOwnershipStub = sandbox.stub(utils, 'checkOwnership');
   const file = 'fixtures/blame.txt';
-  sandbox.stub(cp, 'exec').withArgs(`git blame -w --show-email HEAD~1 -- ${file}`).yields(undefined, blameResult, undefined);
+  sandbox
+    .stub(cp, 'exec')
+    .withArgs(`git blame -w --show-email HEAD~1 -- ${file}`)
+    .yields(undefined, blameResult, undefined);
   const excludeUsers = [];
   const publish = false;
   const currentAuthor = 'doug@example.com';
@@ -29,7 +32,7 @@ test.cb('calls checkOwnership with the appropriate arguments', t => {
       filePath: file,
       ownedLines: 3,
       size: 4,
-      threshold: config.threshold,
+      threshold: config.threshold
     });
     t.is(givenPublish, publish);
   });
@@ -40,7 +43,7 @@ test.cb('calls checkOwnership with the appropriate arguments', t => {
       filePath: file,
       ownedLines: 1,
       size: 4,
-      threshold: config.threshold,
+      threshold: config.threshold
     });
     t.is(givenPublish, publish);
     t.end();
@@ -50,12 +53,17 @@ test.cb('calls checkOwnership with the appropriate arguments', t => {
 });
 
 test.cb('calls checkOwnership without commented lines', t => {
-
-  const blameResult = fs.readFileSync('fixtures/blame-comment-single-line.txt', 'utf8');
+  const blameResult = fs.readFileSync(
+    'fixtures/blame-comment-single-line.txt',
+    'utf8'
+  );
 
   const checkOwnershipStub = sandbox.stub(utils, 'checkOwnership');
   const file = 'fixtures/code-comment-single-line.rb';
-  sandbox.stub(cp, 'exec').withArgs(`git blame -w --show-email HEAD~1 -- ${file}`).yields(undefined, blameResult, undefined);
+  sandbox
+    .stub(cp, 'exec')
+    .withArgs(`git blame -w --show-email HEAD~1 -- ${file}`)
+    .yields(undefined, blameResult, undefined);
   const excludeUsers = [];
   const publish = false;
   const currentAuthor = 'doug@example.com';
@@ -73,7 +81,7 @@ test.cb('calls checkOwnership without commented lines', t => {
       filePath: file,
       ownedLines: 1,
       size: 1,
-      threshold: config.threshold,
+      threshold: config.threshold
     });
     t.end();
   });
@@ -84,15 +92,21 @@ test.cb('calls checkOwnership without commented lines', t => {
 test.cb('calls checkOwnership with comments and multiple authors', t => {
   t.plan(2);
 
-  const blameResult = fs.readFileSync('fixtures/blame-multiple-comment.txt', 'utf8');
+  const blameResult = fs.readFileSync(
+    'fixtures/blame-multiple-comment.txt',
+    'utf8'
+  );
 
   const checkOwnershipStub = sandbox.stub(utils, 'checkOwnership');
   const file = 'fixtures/code-comment-single-line.js';
-  sandbox.stub(cp, 'exec').withArgs(`git blame -w --show-email HEAD~1 -- ${file}`).yields(undefined, blameResult, undefined);
+  sandbox
+    .stub(cp, 'exec')
+    .withArgs(`git blame -w --show-email HEAD~1 -- ${file}`)
+    .yields(undefined, blameResult, undefined);
   const excludeUsers = [];
   const publish = false;
   const currentAuthor = 'doug@example.com';
-  const config = { threshold: 42, exclude: { comments: {'.js': '//'} } };
+  const config = { threshold: 42, exclude: { comments: { '.js': '//' } } };
 
   checkOwnershipStub.onCall(0).callsFake((params, givenPublish) => {
     t.deepEqual(params, {
@@ -101,7 +115,7 @@ test.cb('calls checkOwnership with comments and multiple authors', t => {
       filePath: file,
       ownedLines: 2,
       size: 3,
-      threshold: config.threshold,
+      threshold: config.threshold
     });
   });
   checkOwnershipStub.onCall(1).callsFake((params, givenPublish) => {
@@ -111,7 +125,7 @@ test.cb('calls checkOwnership with comments and multiple authors', t => {
       filePath: file,
       ownedLines: 1,
       size: 3,
-      threshold: config.threshold,
+      threshold: config.threshold
     });
     t.end();
   });

--- a/modules/read-config.js
+++ b/modules/read-config.js
@@ -8,11 +8,14 @@ module.exports = (location = '.pythia-config') => {
   const exclude = configFile.exclude ? readFile(filePath).exclude : {};
   const threshold = configFile.threshold || 20;
 
-  ['users', 'directories', 'files'].forEach((item) => {
+  ['users', 'directories', 'files', 'shas'].forEach((item) => {
     if (typeof exclude[item] === 'undefined') {
       exclude[item] = [];
     }
   });
+
+  // convert all shas to short version
+  exclude.shas = exclude.shas.map(i => i.substring(0,8));
 
   if (typeof exclude.comments === 'undefined') {
     exclude.comments = {};

--- a/modules/read-config.js
+++ b/modules/read-config.js
@@ -1,6 +1,6 @@
-const fs = require('fs'),
-      path = require('path'),
-      readFile = (filePath) => JSON.parse(fs.readFileSync(filePath, 'utf8'));
+const fs = require('fs');
+const path = require('path');
+const readFile = filePath => JSON.parse(fs.readFileSync(filePath, 'utf8'));
 
 module.exports = (location = '.pythia-config') => {
   const filePath = path.join(process.cwd(), location);
@@ -8,21 +8,21 @@ module.exports = (location = '.pythia-config') => {
   const exclude = configFile.exclude ? readFile(filePath).exclude : {};
   const threshold = configFile.threshold || 20;
 
-  ['users', 'directories', 'files', 'shas'].forEach((item) => {
+  ['users', 'directories', 'files', 'shas'].forEach(item => {
     if (typeof exclude[item] === 'undefined') {
       exclude[item] = [];
     }
   });
 
   // convert all shas to short version
-  exclude.shas = exclude.shas.map(i => i.substring(0,8));
+  exclude.shas = exclude.shas.map(i => i.substring(0, 8));
 
   if (typeof exclude.comments === 'undefined') {
     exclude.comments = {};
   }
 
   return {
-  	exclude,
+    exclude,
     threshold
   };
 };

--- a/modules/read-config.test.js
+++ b/modules/read-config.test.js
@@ -43,6 +43,16 @@ test('for a config file with excluded files', t => {
   ]);
 });
 
+test('for a config file without excluded shas', t => {
+  t.deepEqual(readConfig('fixtures/.exclude-files-config').exclude.shas, []);
+});
+
+test('for a config file with excluded shas', t => {
+  t.deepEqual(readConfig('fixtures/.exclude-shas-config').exclude.shas, [
+    'bed1a172'
+  ]);
+});
+
 test('for a config file with excluded comments', t => {
   t.deepEqual(
     readConfig('fixtures/.exclude-comments-config').exclude.comments,

--- a/modules/read-config.test.js
+++ b/modules/read-config.test.js
@@ -1,5 +1,5 @@
-const test = require('ava'),
-readConfig = require('./read-config');
+const test = require('ava');
+const readConfig = require('./read-config');
 
 test('for an empty config file', t => {
   t.deepEqual(readConfig('fixtures/.empty-config'), {
@@ -23,19 +23,31 @@ test('for a config file with threshold', t => {
 });
 
 test('for a config file with excluded users', t => {
-  t.deepEqual(readConfig('fixtures/.exclude-users-config').exclude.users, ['test1@example.com', 'test2@example.com']);
+  t.deepEqual(readConfig('fixtures/.exclude-users-config').exclude.users, [
+    'test1@example.com',
+    'test2@example.com'
+  ]);
 });
 
 test('for a config file with excluded directories', t => {
-  t.deepEqual(readConfig('fixtures/.exclude-directories-config').exclude.directories, ['dir-one', 'dir-two']);
+  t.deepEqual(
+    readConfig('fixtures/.exclude-directories-config').exclude.directories,
+    ['dir-one', 'dir-two']
+  );
 });
 
 test('for a config file with excluded files', t => {
-  t.deepEqual(readConfig('fixtures/.exclude-files-config').exclude.files, ['file-one', 'file-two']);
+  t.deepEqual(readConfig('fixtures/.exclude-files-config').exclude.files, [
+    'file-one',
+    'file-two'
+  ]);
 });
 
 test('for a config file with excluded comments', t => {
-  t.deepEqual(readConfig('fixtures/.exclude-comments-config').exclude.comments, { rb: '#', js: '//' });
+  t.deepEqual(
+    readConfig('fixtures/.exclude-comments-config').exclude.comments,
+    { rb: '#', js: '//' }
+  );
 });
 
 test('for a full featured config file', t => {
@@ -50,4 +62,3 @@ test('for a full featured config file', t => {
     }
   });
 });
-

--- a/modules/read-config.test.js
+++ b/modules/read-config.test.js
@@ -8,7 +8,8 @@ test('for an empty config file', t => {
       users: [],
       directories: [],
       files: [],
-      comments: {}
+      comments: {},
+      shas: []
     }
   });
 });
@@ -44,7 +45,8 @@ test('for a full featured config file', t => {
       users: ['test1@example.com', 'test2@example.com'],
       directories: ['dir-one', 'dir-two'],
       files: ['file-one', 'file-two'],
-      comments: { rb: '#', js: '//' }
+      comments: { rb: '#', js: '//' },
+      shas: []
     }
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -502,6 +502,12 @@
       "integrity": "sha512-dVeOVH/lhZ2Cki5Emh0aKeXUcWG1+EDTkqyzdgPe0ZjzgvBhzSFlogc6rm8uUd0I+XGK5fcp9DsMv5Wofe0/3w==",
       "dev": true
     },
+    "@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
     "ansi-align": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
@@ -1747,6 +1753,30 @@
       "integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY=",
       "dev": true
     },
+    "caller-callsite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
+      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+      "dev": true,
+      "requires": {
+        "callsites": "^2.0.0"
+      }
+    },
+    "caller-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
+      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+      "dev": true,
+      "requires": {
+        "caller-callsite": "^2.0.0"
+      }
+    },
+    "callsites": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+      "dev": true
+    },
     "camelcase": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -2090,6 +2120,18 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
+    },
+    "cosmiconfig": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+      "dev": true,
+      "requires": {
+        "import-fresh": "^2.0.0",
+        "is-directory": "^0.3.1",
+        "js-yaml": "^3.13.1",
+        "parse-json": "^4.0.0"
+      }
     },
     "create-error-class": {
       "version": "3.0.2",
@@ -3351,6 +3393,12 @@
         }
       }
     },
+    "get-stdin": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
+      "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
+      "dev": true
+    },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
@@ -3524,6 +3572,117 @@
       "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew==",
       "dev": true
     },
+    "husky": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-3.0.5.tgz",
+      "integrity": "sha512-cKd09Jy9cDyNIvAdN2QQAP/oA21sle4FWXjIMDttailpLAYZuBE7WaPmhrkj+afS8Sj9isghAtFvWSQ0JiwOHg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "cosmiconfig": "^5.2.1",
+        "execa": "^1.0.0",
+        "get-stdin": "^7.0.0",
+        "is-ci": "^2.0.0",
+        "opencollective-postinstall": "^2.0.2",
+        "pkg-dir": "^4.2.0",
+        "please-upgrade-node": "^3.2.0",
+        "read-pkg": "^5.1.1",
+        "run-node": "^1.0.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        }
+      }
+    },
     "ignore": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.2.tgz",
@@ -3535,6 +3694,16 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
+    },
+    "import-fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
+      "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+      "dev": true,
+      "requires": {
+        "caller-path": "^2.0.0",
+        "resolve-from": "^3.0.0"
+      }
     },
     "import-lazy": {
       "version": "2.1.0",
@@ -3706,6 +3875,12 @@
           "dev": true
         }
       }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
     },
     "is-error": {
       "version": "2.2.2",
@@ -3991,6 +4166,12 @@
       "requires": {
         "package-json": "^4.0.0"
       }
+    },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
     },
     "load-json-file": {
       "version": "4.0.0",
@@ -4296,6 +4477,12 @@
         }
       }
     },
+    "mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
@@ -4339,6 +4526,12 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
     },
     "nise": {
       "version": "1.5.0",
@@ -4505,6 +4698,12 @@
       "requires": {
         "mimic-fn": "^1.0.0"
       }
+    },
+    "opencollective-postinstall": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
+      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
+      "dev": true
     },
     "ora": {
       "version": "3.4.0",
@@ -4804,6 +5003,15 @@
         "find-up": "^4.0.0"
       }
     },
+    "please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "dev": true,
+      "requires": {
+        "semver-compare": "^1.0.0"
+      }
+    },
     "plur": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/plur/-/plur-3.1.1.tgz",
@@ -4825,6 +5033,12 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "dev": true
+    },
     "pretty-ms": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-5.0.0.tgz",
@@ -4832,6 +5046,86 @@
       "dev": true,
       "requires": {
         "parse-ms": "^2.1.0"
+      }
+    },
+    "pretty-quick": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-1.11.1.tgz",
+      "integrity": "sha512-kSXCkcETfak7EQXz6WOkCeCqpbC4GIzrN/vaneTGMP/fAtD8NerA9bPhCUqHAks1geo7biZNl5uEMPceeneLuA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.0",
+        "execa": "^0.8.0",
+        "find-up": "^2.1.0",
+        "ignore": "^3.3.7",
+        "mri": "^1.1.0",
+        "multimatch": "^3.0.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "ignore": {
+          "version": "3.3.10",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+          "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        }
       }
     },
     "process-nextick-args": {
@@ -5171,6 +5465,12 @@
         "glob": "^7.1.3"
       }
     },
+    "run-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/run-node/-/run-node-1.0.0.tgz",
+      "integrity": "sha512-kc120TBlQ3mih1LSzdAJXo4xn/GWS2ec0l3S+syHDXP9uRr0JAT8Qd3mdMuyjqCzeZktgP3try92cEgf9Nks8A==",
+      "dev": true
+    },
     "run-parallel": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
@@ -5196,6 +5496,12 @@
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
       "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
     },
     "semver-diff": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "pythia": "./bin/pythia"
   },
   "scripts": {
-    "test": "ava *.test.js modules/*.test.js --serial",
+    "test": "ava modules/*.test.js --serial",
     "release": "npm test && tom"
   },
   "repository": {
@@ -31,7 +31,15 @@
   },
   "devDependencies": {
     "ava": "^2.2.0",
+    "husky": "^3.0.5",
+    "prettier": "1.18.2",
+    "pretty-quick": "^1.11.1",
     "sinon": "^7.3.2",
     "tom-sawyer": "^0.1.7"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
+    }
   }
 }


### PR DESCRIPTION
Now you can blacklist a sha, for instance if there was a large
codemod/prettier style change made to the code base that doesn't
really reflect the authorship of lines anymore.

Add the SHA to the config file and it will be excluded from the
ownership calculation.